### PR TITLE
Use hudson.FilePath instead of java.io.files for accessing files

### DIFF
--- a/src/main/java/io/jenkins/plugins/oci/artifact/UploadArtifactNotifier.java
+++ b/src/main/java/io/jenkins/plugins/oci/artifact/UploadArtifactNotifier.java
@@ -97,9 +97,9 @@ public class UploadArtifactNotifier extends Notifier implements SimpleBuildStep 
     void uploadArtifacts(GenericArtifactsContentClient client, List<UploadArtifactDetails> details,
                          FilePath workspace, TaskListener listener ) throws Exception {
         for (UploadArtifactDetails detail : details) {
-            File artifactFile = new File(URLDecoder.decode(workspace.toURI().getPath(), UTF_8_ENCODING), detail.getSourcePath());
-            try (BufferedInputStream artifactContent = new BufferedInputStream(new FileInputStream(artifactFile))) {
-                listener.getLogger().println(String.format("Uploading Artifact located at %s", artifactFile.getPath()));
+            FilePath artifactFile = new FilePath(workspace, detail.getSourcePath());
+            try (BufferedInputStream artifactContent = new BufferedInputStream(artifactFile.read())) {
+                listener.getLogger().println(String.format("Uploading Artifact located at %s", artifactFile.absolutize()));
                 listener.getLogger().println(String.format("Artifact Name: %s", artifactFile.getName()));
                 listener.getLogger().println(String.format("Artifact Size: %s", artifactFile.length()));
 


### PR DESCRIPTION
Jenkins provides FilePath class(https://javadoc.jenkins.io/hudson/FilePath.html) that provides remote file access support in a distributed environment. We're currently using java.io.file which tries to find the file in the master node.
Testing:
UploadArtifactNotifierIntegrationTest - successful
Tested a sample pipeline locally with both distributed and single node environment. Worked successfully.
